### PR TITLE
Fix compilation on gcc13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CC = gcc
 
+CFLAGS = -std=c99
+
 LIBS :=-lgdi32 -lm -lwinmm -ggdb 
 EXT = .exe
 STATIC =
@@ -83,16 +85,16 @@ endif
 LIBS += -I./include libs.o -lm
 
 all: $(SRC) libs.o
-	$(CC) $(SRC)  $(LINK_GL1) $(LIBS) -o rgfw_example$(EXT)
+	$(CC) $(CFLAGS) $(SRC)  $(LINK_GL1) $(LIBS) -o rgfw_example$(EXT)
 
 libs.o: libs.o
-	$(CC) libs.c -c -I./include 
+	$(CC) $(CFLAGS) libs.c -c -I./include 
 
 clean:
 	rm -f *.exe rgfw_example *.o 
 
 debug: $(SRC) libs.o
-	$(CC) $(SRC) $(LINK_GL1) $(LIBS) -D RGFW_DEBUG -o rgfw_example$(EXT) 
+	$(CC) $(CFLAGS) $(SRC) $(LINK_GL1) $(LIBS) -D RGFW_DEBUG -o rgfw_example$(EXT) 
 ifeq (,$(filter $(CC),emcc))
 	.$(OS_DIR)rgfw_example$(EXT)
 endif

--- a/include/PureDOOM.h
+++ b/include/PureDOOM.h
@@ -9082,7 +9082,7 @@ weaponinfo_t weaponinfo[NUMWEAPONS] =
 #if defined(DOOM_WIN32)
 
 
-#define X_OK 1
+#define X_OK 0
 #define W_OK 2
 #define R_OK 4
 #define RW_OK 6

--- a/include/PureDOOM.h
+++ b/include/PureDOOM.h
@@ -9082,7 +9082,7 @@ weaponinfo_t weaponinfo[NUMWEAPONS] =
 #if defined(DOOM_WIN32)
 
 
-#define X_OK 0
+#define X_OK 1
 #define W_OK 2
 #define R_OK 4
 #define RW_OK 6


### PR DESCRIPTION
The project fails to build on gcc13 (and possibly recent clang too) because they now default to std23.

This patch adds compiler flags to build in c99 mode. This is the easier fix and it is in line with RGFW's goal of having c99 as a baseline.

But if you prefer I can also fix the issues in DOOM directly instead:

- [Function declarations now have to be full prototypes](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2841.htm). It can be fixed by completing the prototypes in PureDOOM.h line 16482-16558 or by removing those definitions and moving the array data of state_t states[NUMSTATES] lower down, after they've been declared.
- [true/false are now keywords](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2935.pdf), so it doesn't like the typedef enum in PureDOOM.h. Removing the enum and keeping only `typedef int doom_boolean` is a possible fix. Another is to rely on stdbool.
